### PR TITLE
add support for STROKESTATS and GET_DISPLAYUNITS commands from the PDF

### DIFF
--- a/pyrow/csafe/csafe_dic.py
+++ b/pyrow/csafe/csafe_dic.py
@@ -65,6 +65,7 @@ cmds['CSAFE_PM_GET_WORKOUTSTATE'] = [0x8D, [], 0x1A]
 cmds['CSAFE_PM_GET_WORKOUTINTERVALCOUNT'] = [0x9F, [], 0x1A]
 cmds['CSAFE_PM_GET_INTERVALTYPE'] = [0x8E, [], 0x1A]
 cmds['CSAFE_PM_GET_RESTTIME'] = [0xCF, [], 0x1A]
+cmds['CSAFE_PM_GET_DISPLAYUNITS'] = [0x8B, [], 0x1A]
 
 #PM3 Specific Long Commands
 cmds['CSAFE_PM_SET_SPLITDURATION'] = [0x05, [1, 4], 0x1A] #Time(0)/Distance(128), Duration
@@ -133,6 +134,7 @@ resp[0x1A8D] = ['CSAFE_PM_GET_WORKOUTSTATE', [1,]] #Workout State
 resp[0x1A9F] = ['CSAFE_PM_GET_WORKOUTINTERVALCOUNT', [1,]] #Workout Interval Count
 resp[0x1A8E] = ['CSAFE_PM_GET_INTERVALTYPE', [1,]] #Interval Type
 resp[0x1ACF] = ['CSAFE_PM_GET_RESTTIME', [2,]] #Rest Time
+cmds[0x1A8B] = ['CSAFE_PM_GET_DISPLAYUNITS', [1]] # Display Units Type
 
 #Response Data to PM3 Specific Long Commands
 resp[0x1A05] = ['CSAFE_PM_SET_SPLITDURATION', [0,]] #No variables returned !! double check

--- a/pyrow/csafe/csafe_dic.py
+++ b/pyrow/csafe/csafe_dic.py
@@ -71,6 +71,9 @@ cmds['CSAFE_PM_SET_SPLITDURATION'] = [0x05, [1, 4], 0x1A] #Time(0)/Distance(128)
 cmds['CSAFE_PM_GET_FORCEPLOTDATA'] = [0x6B, [1,], 0x1A] #Block Length
 cmds['CSAFE_PM_SET_SCREENERRORMODE'] = [0x27, [1,], 0x1A] #Disable(0)/Enable(1)
 cmds['CSAFE_PM_GET_HEARTBEATDATA'] = [0x6C, [1,], 0x1A] #Block Length
+cmds['CSAFE_PM_GET_STROKESTATS'] = [0x6E, [0,], 0x1A] # <reserved> (use 0 for now)
+
+
 
 
 #resp[0xCmd_Id] = [COMMAND_NAME, [Bytes, ...]]
@@ -138,3 +141,4 @@ resp[0x1A6B] = ['CSAFE_PM_GET_FORCEPLOTDATA', [
 resp[0x1A27] = ['CSAFE_PM_SET_SCREENERRORMODE', [0,]]  #No variables returned !! double check
 resp[0x1A6C] = ['CSAFE_PM_GET_HEARTBEATDATA', [
     1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2]] #Bytes read, data ...
+resp[0x1A6E] = ['CSAFE_PM_GET_STROKESTATS', [2,1,2,1,2,2,2,2,2]] # Stroke Distance (2 bytes), drive time (1 byte), recovery time (2 bytes), stroke length (one byte), stroke count (2 bytes), Stroke peak force (2bytes), Stroke Impulse Force (2 bytes), Stroke Average Force (2 bytes), Work per stroke (2 bytes)


### PR DESCRIPTION
Went through all the commands in the PDF and noticed the one I needed for retrieving things like rower work and stroke impulse were not set up and I was getting an error like:

```
  File "/home/ace/.local/share/virtualenvs/PylogPlot-Y4XmFPYJ/lib/python3.8/site-packages/pyrow/csafe/csafe_cmd.py", line 14, in __int2bytes
    if not 0 <= integer <= 2 ** (8 * numbytes):
TypeError: '<=' not supported between instances of 'int' and 'str'
```

Turns out this was because the definition for this command was not included in the `csafe_dic.py` file, so I added it. Also went through to double check all the others to make sure there were no other implemented (by Concept2) commands that were not set up, and thats where i caught and added GET_DISPLAYUNITS